### PR TITLE
Fix IPv4, IPv6, and Subdomain Issues with Dynu DNS usage.

### DIFF
--- a/dynudns-addon/DOCS.md
+++ b/dynudns-addon/DOCS.md
@@ -123,7 +123,10 @@ The number of seconds to wait before updating DynuDNS subdomains and renewing Le
 
 ## Credit
 
-This add-on is at 99% a copy of the official DuckDNS add-on 
+This add-on is at 94% a copy of the official DuckDNS add-on and ACME.sh
+[upstream run.sh]: https://github.com/home-assistant/addons/blob/master/duckdns/data/run.sh
+[upstream hook.sh]: https://github.com/home-assistant/addons/blob/master/duckdns/data/hook.sh
+[upstream dnsdynu.sh]: https://github.com/acmesh-official/acme.sh/blob/master/dnsapi/dns_dynu.sh
 
 ## Support
 

--- a/dynudns-addon/config.json
+++ b/dynudns-addon/config.json
@@ -6,7 +6,9 @@
   "url": "https://github.com/koying/ha-addons/tree/main/dynudns-addon",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "startup": "services",
-  "init": "false",
+  "init": false,
+  "hassio_api": true,
+  "hassio_role": "default",
   "map": ["ssl:rw"],
   "options": {
     "lets_encrypt": {

--- a/dynudns-addon/data/run.sh
+++ b/dynudns-addon/data/run.sh
@@ -12,8 +12,10 @@ WORK_DIR=/data/workdir
 LE_UPDATE="0"
 
 # DynuDNS
-if bashio::config.has_value "ipv4"; then IPV4=$(bashio::config 'ipv4'); else IPV4="https://ipv4.text.wtfismyip.com"; fi
-if bashio::config.has_value "ipv6"; then IPV6=$(bashio::config 'ipv6'); else IPV6="https://ipv6.text.wtfismyip.com"; fi
+if bashio::config.has_value "ipv4"; then ipv4_fixed=$(bashio::config 'ipv4'); else ipv4_fixed=""; fi
+if bashio::config.has_value "ipv6"; then ipv6_fixed=$(bashio::config 'ipv6'); else ipv6_fixed=""; fi
+QUERY_URL_IPV4="https://ipv4.text.wtfismyip.com"
+QUERY_URL_IPV6="https://ipv6.text.wtfismyip.com"
 TOKEN=$(bashio::config 'token')
 DOMAINS=$(bashio::config 'domains')
 WAIT_TIME=$(bashio::config 'seconds')
@@ -45,6 +47,8 @@ function le_renew() {
     LE_UPDATE="$(date +%s)"
 }   
 
+bashio::log.info "Initializing Dynu DNS Home Assistant Add-On for Domain(s): $(echo -n "${DOMAINS}")"
+
 # Register/generate certificate if terms accepted
 if bashio::config.true 'lets_encrypt.accept_terms'; then
     # Init folder structs
@@ -66,26 +70,105 @@ if bashio::config.true 'lets_encrypt.accept_terms'; then
     fi
 fi
 
+bashio::log.info "Entering main Dynu DNS loop"
 # Run dynu
 while true; do
 
-    [[ ${IPV4} != *:/* ]] && ipv4=${IPV4} || ipv4=$(curl -s -f -m 10 "${IPV4}") || true 
-    [[ ${IPV6} != *:/* ]] && ipv6=${IPV6} || ipv6=$(curl -s -f -m 10 "${IPV6}") || true 
+    # Determine IPv4 Address
+    if [[ -n "$ipv4_fixed" ]]; then # use fixed IPv4 address
+        bashio::log.info "Using parsed argument for fixed IPv4: ${ipv4_fixed}"
+        if [[ ${ipv4_fixed} == *.* ]]; then
+            ipv4=${ipv4_fixed}
+        else
+            bashio::log.error "It appears the Add-On Argument: ipv4_fixed is not an IP address "
+            exit 1
+        fi
+    else  # Ask external server for my IPv4 address, since HA probably doesn't know it.
+        ipv4_queried=$(curl -s -f -m 10 "${QUERY_URL_IPV4}")
+        if [[ ${ipv4_queried} == *.* ]]; then
+            bashio::log.info "According to: ${QUERY_URL_IPV4} , IPv4 address is ${ipv4_queried}"
+            ipv4=${ipv4_queried}
+        else
+            bashio::log.warning "It appears ipv4_queried: ${ipv4_queried} returned from ${QUERY_URL_IPV4} is not an IP address "
+            sleep 5
+            continue
+        fi
 
-    bashio::log.debug "ipv4:" "$ipv4"
-    bashio::log.debug "ipv6:" "$ipv6"
+    fi
 
+    # Determine IPv6 Address
+    if [[ -n "$ipv6_fixed" ]]; then # use fixed IPv6 address
+        bashio::log.info "Using parsed argument for fixed IPv6: ${ipv6_fixed}"
+        if [[ ${ipv6_fixed} == *.* ]]; then
+            ipv6=${ipv6_fixed}
+        else
+            bashio::log.error "It appears the Add-On Argument: ipv6_fixed is not an IP address "
+            sleep 5
+            exit 1
+        fi
+    else  # Get IPv6 address from HA API, since add-on container does not have IPv6 address.
+        ipv6=
+        bashio::cache.flush_all
+        for addr in $(bashio::network.ipv6_address); do
+	    # Skip non-global addresses
+	    if [[ ${addr} != fe80:* && ${addr} != fc* && ${addr} != fd* ]]; then
+              ipv6=${addr%/*}
+              bashio::log.info "According to the HA Supervisor API, IPv6 address is ${ipv6}"
+              break
+            fi
+        done
+    fi
+
+    # Update each domain
     for domain in ${DOMAINS}; do
+
+        # Get current domain configuration
         _get_domain_id "${domain}"
-        bashio::log.debug "DynuDnsId:" "${DynuDnsId}"
-        answer=$(curl -s -X POST -H "API-Key: $TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$DynuDnsId" -d "{\"name\":\"$domain\",\"ipv4Address\": \"${ipv4}\",\"ipv6Address\": \"${ipv6}\"}")
-        bashio::log.debug "${answer}"
+        bashio::log.info "Getting current domain configuration for domain: ${domain}"
+        bashio::log.debug "DynuDnsId: ${DynuDnsId}"
+
+        current_domain_config="$(curl -s -f -H "API-Key: $TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$DynuDnsId")"
+        current_ipv4_address=$(echo "$current_domain_config" | jq -r '.ipv4Address')
+        current_ipv6_address=$(echo "$current_domain_config" | jq -r '.ipv6Address')
+        statusCode=$(echo "$current_domain_config" | jq '.statusCode')
+
+        # Create new domain configuration
+        new_domain_config=$current_domain_config
+        if  [ "$statusCode" -eq 200 ]; then
+            bashio::log.info "  - Dynu DNS get config Success. \"statusCode\": $statusCode"
+            if  [[ "${ipv4}" == *.* ]]; then # Replace ipv4Address and ipv4 fields
+                new_domain_config=$(echo "$new_domain_config" | jq ".ipv4Address = \"${ipv4}\" | .ipv4 = true")
+            fi
+            if  [[ "${ipv6}" == *:* ]]; then # Replace ipv6Address and ipv6 fields
+                new_domain_config=$(echo "$new_domain_config" | jq ".ipv6Address = \"${ipv6}\" | .ipv6 = true")
+            fi
+        else
+            bashio::log.warning "  - Dynu DNS get config failed, not \"statusCode:\" ${statusCode}. It answered: ${answer}"
+            break
+        fi
+
+        # Update Domain config if it's different
+        bashio::log.info "Updating Dynu DNS: ${domain} IP addresses"
+        if [[ "$current_ipv4_address" != "$ipv4" ]] || [[ "$current_ipv6_address" != "$ipv6" ]] ; then
+
+            answer="$(curl -s -f -X POST -H "API-Key: $TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$DynuDnsId" -d "${new_domain_config}")"
+            statusCode=$(echo "$answer" | jq '.statusCode')
+
+            if [ "$statusCode" -eq 200 ]; then
+                bashio::log.info "  - Dynu DNS IP update Success: "statusCode:" ${statusCode}"
+            else
+                bashio::log.warning "  - Dynu DNS IP update did not succeed. "statusCode:" "$statusCode" . It answered: ${answer}"
+            fi
+        else
+            bashio::log.info "  - Skipping IP update since the IPv4 and IPv6 addresses are the same as on Dynu DNS."
+
+        fi
     done
-    
+
     now="$(date +%s)"
     if bashio::config.true 'lets_encrypt.accept_terms' && [ $((now - LE_UPDATE)) -ge 43200 ]; then
         le_renew
     fi
-    
+
     sleep "${WAIT_TIME}"
 done


### PR DESCRIPTION
Hello,

With the commits in this PR, I believe it will be possible to close most of the issues!

A quick explanation of the fixes:
**Subdomains:** #9 In the Dynu DNS API, subdomains are almost full domains. The full domain object (of the subdomain) must be retrieved, modified, and returned, rather than modifying the records of the root domain.

**IPv6:** #12 The container doesn't have access to IPv6, and hence can't see it's interfaces or make calls to external IPv6 servers to determine it's IP Address. The solution, to use HA Supervisor API through Bashio, inspired by this [commit](https://github.com/home-assistant/addons/pull/2490/commits/db3f53f5f557f587c4742073d1b957325a7d3abb) from @pvizeli in the Duck DNS add-on.

**Error Handling, Printing, and Checking Inputs:** #8 Should not use a blank IPv4 address

**Improved API usage:** #3 The previous call updated certain fields of the Domain settings, however this left most at blank or default, so it "overwrote" whenever it updated. Very useful [Dynu Swagger API Documentation](https://www.dynu.com/Support/API) for testing.

I tested:
- Use of paid domain
- Use of subdomain under paid domain
- IPv4
- IPv6

Needs additional testing:
- Aliases -> Still needed with subdomain fix?
- Wildcard -> I didn't test, but it should work for domains and subdomains.
- Free domains
- LE Certificate Validity.

