### PR TITLE
Major re-write of Dynu DNS Add On.

### DIFF
--- a/dynudns-addon/config.json
+++ b/dynudns-addon/config.json
@@ -16,10 +16,10 @@
       "certfile": "fullchain.pem",
       "keyfile": "privkey.pem"
     },
-    "token": null,
+    "dns_api_token": null,
     "domains": [null],
     "aliases": [],
-    "seconds": 300
+    "ip_update_wait_seconds": 300
   },
   "schema": {
     "lets_encrypt": {
@@ -27,13 +27,13 @@
       "certfile": "str",
       "keyfile": "str"
     },
-    "ipv4": "str?",
-    "ipv6": "str?",
-    "token": "str",
+    "ipv4_fixed": "str?",
+    "ipv6_fixed": "str?",
+    "dns_api_token": "str",
     "domains": ["str"],
     "aliases": [
       {"domain": "str", "alias": "str"}
     ],
-    "seconds": "int"
+    "ip_update_wait_seconds": "int"
   }
 }

--- a/dynudns-addon/data/ddns.sh
+++ b/dynudns-addon/data/ddns.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/with-contenv bashio
+
+# CONSTANTS
+QUERY_URL_IPV4="https://ipv4.text.wtfismyip.com"
+
+function is_domain() {
+    local domain="$1"
+
+    # Regex for checking if a string is a domain name with at least one period
+    # This pattern checks for a sequence of alphanumeric characters (including hyphens)
+    # followed by a period, and then another sequence of alphanumeric characters.
+    local regex="^([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$"
+
+    if [[ $domain =~ $regex ]]; then
+        bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "$domain is a valid domain."
+        return 0
+    else
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "$domain is not a valid domain."
+        return 1
+    fi
+}
+
+function hassio_determine_ipv4_address(){
+
+    # Determine IPv4 Address
+    if [[ -n "$IPV4_FIXED" ]]; then # use fixed IPv4 address
+        bashio::log.info "Using parsed argument for fixed IPv4: ${IPV4_FIXED}"
+        if [[ ${IPV4_FIXED} == *.* ]]; then
+            current_ipv4_address=${IPV4_FIXED}
+            return 0
+        else
+            bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "It appears the Add-On Argument: ipv4_fixed is not an IP address"
+            exit 1
+        fi
+    else  # Ask external server for my IPv4 address, since HA probably doesn't know it.
+        ipv4_queried=$(curl -s -f -m 10 "${QUERY_URL_IPV4}")
+        if [[ ${ipv4_queried} == *.* ]]; then
+            bashio::log.info "According to: ${QUERY_URL_IPV4} , IPv4 address is ${ipv4_queried}"
+            current_ipv4_address=${ipv4_queried}
+            return 0
+        else
+            bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "It appears ipv4_queried: ${ipv4_queried} returned from ${QUERY_URL_IPV4} is not an IP address"
+            return 1
+        fi
+    fi
+    return 1
+    
+}
+
+function hassio_determine_ipv6_address(){
+
+    # Determine IPv6 Address
+    if [[ -n "$IPV6_FIXED" ]]; then # use fixed IPv6 address
+        bashio::log.info "Using parsed argument for fixed IPv6: ${IPV6_FIXED}"
+        if [[ ${IPV6_FIXED} == *:* ]]; then
+            current_ipv6_address=${IPV6_FIXED}
+            return 0
+        else
+            bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "It appears the Add-On Argument: ipv6_fixed is not an IP address "
+            exit 1
+        fi
+    else  # Get IPv6 address from HA API, since add-on container does not have IPv6 address.
+        bashio::cache.flush_all
+        for addr in $(bashio::network.ipv6_address); do
+            # Skip non-global addresses
+            if [[ ${addr} != fe80:* && ${addr} != fc* && ${addr} != fd* ]]; then
+                current_ipv6_address=${addr%/*}
+                bashio::log.info "According to the HA Supervisor API, IPv6 address is ${current_ipv6_address}"
+                return 0
+            fi
+        done
+        return 1
+    fi
+    return 1
+}
+
+function hassio_get_config_variables(){
+
+    if bashio::config.has_value "ipv4_fixed"; then IPV4_FIXED=$(bashio::config 'ipv4_fixed'); else IPV4_FIXED=""; fi
+    if bashio::config.has_value "ipv6_fixed"; then IPV6_FIXED=$(bashio::config 'ipv6_fixed'); else IPV6_FIXED=""; fi
+    if bashio::config.has_value "aliases"; then ALIASES=$(bashio::config 'aliases'); else ALIASES=""; fi
+
+    DNS_API_TOKEN=$(bashio::config 'dns_api_token')
+    DOMAINS=$(bashio::config 'domains')
+    IP_UPDATE_WAIT_SECONDS=$(bashio::config 'ip_update_wait_seconds')
+    LE_TERMS_ACCEPTED=$(bashio::config 'lets_encrypt.accept_terms')
+
+    # Check if DOMAINS are valid domains.
+    for domain in ${DOMAINS}; do
+       if is_domain $domain; then
+            bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "domain $domain is a valid domain."
+        else
+            bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "domain $domain is not a valid domain... "
+            return 1
+        fi
+    done
+
+    # Check if ALIASES are valid domains.
+    for domain in $ALIASES; do
+        for alias in $domain; do
+            if is_domain $alias; then
+                bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "alias $domain is a valid domain."
+            else
+                bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "alias $domain is not a valid domain..."
+                return 1
+            fi
+        done
+    done
+
+    # Check if /data/options.json is healthy
+    if jq "select(.domain != null)" "$CONFIG_PATH" ; then
+        bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "jq \"select(.domain != null)\" /data/options.json returned 0"
+    else
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "jq \"select(.domain != null)\" /data/options.json did not 0"
+        return 1
+    fi
+
+    return 0
+}

--- a/dynudns-addon/data/dns_dynu.sh
+++ b/dynudns-addon/data/dns_dynu.sh
@@ -1,39 +1,78 @@
 #!/usr/bin/with-contenv bashio
 
-#Token
-#Dynu_Token=""
-#
-#Endpoint
-Dynu_EndPoint="https://api.dynu.com/v2"
-#
-#Author: Dynu Systems, Inc.
-#Report Bugs here: https://github.com/shar0119/acme.sh
-#
+## CONSTANTS
+declare DNS_API_TOKEN
+DNS_API_ENDPOINT='https://api.dynu.com/v2'
+
+
+## VARIABLES
+declare current_domain_config
+declare domain_id
+
 ########  Public functions #####################
+function dns_dynu_update_ipv4_ipv6() {
+    local domain="$1"
+    local current_ipv4_address="$2"
+    local current_ipv6_address="$3"
+
+    if ! _get_domain_config "$domain"; then
+      bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "DynuDNS _get_domain_config API call failed."
+      return 1
+    fi
+
+    dns_configured_ipv4_address=$(echo "$current_domain_config" | jq -r '.ipv4Address')
+    dns_configured_ipv6_address=$(echo "$current_domain_config" | jq -r '.ipv6Address')
+    statusCode=$(echo "$current_domain_config" | jq '.statusCode')
+
+    # Create new domain configuration and replace IPv4 and IPv6 addresses
+    new_domain_config=$current_domain_config
+
+    if  [[ "$current_ipv4_address" == *.* ]]; then # Replace ipv4Address and ipv4 fields
+        new_domain_config=$(echo "$new_domain_config" | jq ".ipv4Address = \"$current_ipv4_address\" | .ipv4 = true")
+    fi
+    if  [[ "$current_ipv6_address" == *:* ]]; then # Replace ipv6Address and ipv6 fields
+        new_domain_config=$(echo "$new_domain_config" | jq ".ipv6Address = \"$current_ipv6_address\" | .ipv6 = true")
+    fi
+
+    # Update Domain config if it's different
+    bashio::log.info "Updating Dynu DNS: $domain IP addresses"
+    if [[ "$dns_configured_ipv4_address" != "$current_ipv4_address" ]] || [[ "$dns_configured_ipv6_address" != "$current_ipv6_address" ]] ; then
+
+      # Set the new domain configuration with updated IP addresses.
+      if ! _set_domain_config "$domain" "$new_domain_config"; then
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "DynuDNS _set_domain_config API call failed."
+        return 1
+      else
+        bashio::log.info "[${FUNCNAME[0]} completed successfully!"
+        return 0
+      fi
+    fi
+}
 
 #Usage: add _acme-challenge.www.domain.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
-dns_dynu_add() {
-  fulldomain=$1
-  txtvalue=$2
+dns_dynu_add_txt_record() {
+  local fulldomain="$1"
+  local txtvalue="$2"
 
-  if [ -z "$Dynu_Token" ]; then
-    bashio::log.error "Missing Dynu token."
+  if [ -z "$DNS_API_TOKEN" ]; then
+    bashio::log.warn "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Missing Dynu DNS_API_TOKEN."
     return 1
   fi
 
-  bashio::log.info "Get domain ID"
+  bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Get domain ID"
   if ! _get_domain_id "$fulldomain"; then
-    bashio::log.error "Invalid domain."
+    bashio::log.warn "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Invalid domain."
     return 1
   fi
 
-  bashio::log.info "Creating TXT record."
-  if ! _dynu_rest POST "dns/$DynuDnsId/record" "{\"domainId\":\"$DynuDnsId\",\"nodeName\":\"_acme-challenge\",\"recordType\":\"TXT\",\"textData\":\"$txtvalue\",\"state\":true,\"ttl\":90}"; then
+  bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Creating TXT record."
+  if ! _dynu_rest POST "dns/$domain_id/record" "{\"domainId\":\"$domain_id\",\"nodeName\":\"_acme-challenge\",\"recordType\":\"TXT\",\"textData\":\"$txtvalue\",\"state\":true,\"ttl\":90}"; then
+    bashio::log.warn "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Dynu Rest API call failed."
     return 1
   fi
 
   if ! _contains "$response" "200"; then
-    bashio::log.error "Could not add TXT record."
+    bashio::log.warn "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Could not add TXT record."
     return 1
   fi
 
@@ -41,65 +80,155 @@ dns_dynu_add() {
 }
 
 #Usage: rm _acme-challenge.www.domain.com "XKrxpRBosdIKFzxW_CT3KLZNf6q0HG9i01zxXp5CPBs"
-dns_dynu_rm() {
-  fulldomain=$1
-  txtvalue=$2
+dns_dynu_rm_record() {
+  local fulldomain="$1"
+  local txtvalue="$2"
 
-  if [ -z "$Dynu_Token" ]; then
-    bashio::log.error "Missing Dynu token."
+  if [ -z "$DNS_API_TOKEN" ]; then
+    bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Missing Dynu DNS_API_TOKEN."
     return 1
   fi
 
   bashio::log.info "Get domain ID"
   if ! _get_domain_id "$fulldomain"; then
-    bashio::log.error "Invalid domain."
+    bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Invalid domain."
     return 1
   fi
 
   bashio::log.info "Checking for TXT record."
-  if ! _get_recordid "$fulldomain" "$txtvalue"; then
-    bashio::log.error "Could not get TXT record id."
+  if ! _get_record_id "$fulldomain" "$txtvalue"; then
+    bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Could not get TXT record id."
     return 1
   fi
 
   if [ "$_dns_record_id" = "" ]; then
-    bashio::log.error "TXT record not found."
+    bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "TXT record not found."
     return 1
   fi
 
   bashio::log.info "Removing TXT record."
-  if ! _delete_txt_record "$_dns_record_id"; then
-    bashio::log.error "Could not remove TXT record $_dns_record_id."
+  if ! _delete_record "$domain_id" "$_dns_record_id"; then
+    bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Could not remove TXT record $_dns_record_id."
   fi
 
   return 0
 }
 
 _get_domain_id() {
-  domain=$1
+  local domain="$1"
+
+  # Perform server request
+  bashio::log.debug "${FUNCNAME[0]} $@ Getting DynuDNS ID for $domain"
   if ! _dynu_rest GET "dns" ""; then
-    bashio::log.warning "DynuDNS GET dns API call failed."
+    bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "DynuDNS GET dns API call failed."
+    return 1
+  else
+    bashio::log.trace "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "RESPONSE FOLLOWS \nresponse='$(echo $response)' \n"
+  fi
+
+  # Check if response has JSON domains array and grab it
+  if ! domains=$(echo "$response" | jq -e '.domains'); then
+    bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "response does not have JSON domains array."
+    return 1
+  else
+    bashio::log.trace "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "DOMAINS FOLLOWS \ndomains='$(echo $domains | jq)' \n"
+  fi
+
+  # Check if domains has the domain of interest and grab it
+  if ! domain_config=$(echo "$domains" | jq -e --arg name "$domain" '.[] | select(.name == $name)' ); then
+    bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "domains does not have domain_config for $domain."
+    return 1
+  else
+    bashio::log.trace "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "DOMAIN CONFIG FOLLOWS \ndomain_config='$(echo $domain_config)' \n"
+  fi 
+
+  # Check if domain_config has the numeric ID of interest and grab it
+  if ! domain_id_parsed=$(echo "$domain_config" | jq -e '.id'); then
+    bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "domain_config does not have domain_id."
+    return 1
+  else
+    bashio::log.trace "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "DOMAIN ID FOLLOWS \ndomain_id='$(echo $domain_id_parsed)' \n"
+  fi 
+
+  # Check if domain_id_parsed is non-empty and is a number greater than 100 and grab it.
+  if [[ -n "$domain_id_parsed" ]] && [[ "$domain_id_parsed" =~ ^[0-9]+$ ]] && [[ 100 -le $domain_id_parsed ]]; then
+    domain_id=$domain_id_parsed
+    bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Successfully fetched domain_id: $domain_id"
+    return 0
+  else
+    bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "Failed to parse domain_id: $domain_id out of JSON response."
     return 1
   fi
 
-  bashio::log.debug "$domain" "$response"
-
-  if jq --arg name "$domain" 'any(.domains[]; .name == $name)'; then
-    DynuDnsId=$(echo $response | jq --arg name "$domain" '.domains[] | select(.name == $name) | .id')
-    bashio::log.debug "Fetched DynuDnsId: " "${DynuDnsId}"
-    return 0
-  fi
-  
-  bashio::log.warning "Failed to get DynuDNS domain id"
+  bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "Failed to get DynuDNS domain id, unknown error. Exiting."
   return 1
 
 }
 
-_get_recordid() {
-  fulldomain=$1
-  txtvalue=$2
+function _get_domain_config(){
+    local domain="$1"
 
-  if ! _dynu_rest GET "dns/$DynuDnsId/record" ""; then
+    # Get domain numeric id
+    if _get_domain_id "${domain}"; then
+        bashio::log.debug "domain_id: ${domain_id}"
+    else
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "Failed to get domain_id for $domain."
+        return 1
+    fi 
+        
+    # Get current domain configuration
+    bashio::log.info "Getting current domain configuration for domain: ${domain}"
+    if current_domain_config="$(curl -s -f -H "API-Key: $DNS_API_TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$domain_id")"; then
+        bashio::log.debug "domain_id: ${domain_id}" "$LINENO" "${BASH_SOURCE[0]}"
+    else
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "Failed to get request domain configuration for $domain."
+        return 1
+    fi 
+
+    # Check domain request status code
+    statusCode=$(echo "$current_domain_config" | jq '.statusCode')
+    if  [ "$statusCode" -eq 200 ]; then
+        bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Dynu DNS get config Success. \"statusCode\": $statusCode"
+    else
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Dynu DNS get config failed, not \"statusCode:\" ${statusCode}. It answered: ${answer}"
+        return 1
+    fi
+
+}
+
+function _set_domain_config(){
+    local domain="$1"
+    local new_domain_config="$2"
+
+    # Get domain numeric id
+    if _get_domain_id "${domain}"; then
+        bashio::log.trace "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "domain_id: $domain_id"
+    else
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "Failed to get domain_id for $domain. Skipping."
+        return 1
+    fi 
+        
+    # Update Domain config
+    bashio::log.info "Updating Dynu DNS: ${domain} Domain Configuration"
+
+    answer="$(curl -s -f -X POST -H "API-Key: $DNS_API_TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$domain_id" -d "$new_domain_config")"
+    statusCode=$(echo "$answer" | jq '.statusCode')
+
+    if [ "$statusCode" -eq 200 ]; then
+        bashio::log.info "Dynu DNS IP update Success. "statusCode:" $statusCode"
+        return 0
+    else
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "Dynu DNS IP update did not succeed. "statusCode:" "$statusCode" . It answered: $answer"
+        return 1
+    fi
+
+}
+
+_get_record_id() {
+  local fulldomain="$1"
+  local txtvalue="$2"
+
+  if ! _dynu_rest GET "dns/$domain_id/record" ""; then
     return 1
   fi
 
@@ -109,13 +238,16 @@ _get_recordid() {
   fi
 
   _dns_record_id=$(printf "%s" "$response" | sed -e 's/[^{]*\({[^}]*}\)[^{]*/\1\n/g' | grep "\"textData\":\"$txtvalue\"" | sed -e 's/.*"id":\([^,]*\).*/\1/')
+  bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "DynuDNS _dns_record_id id is: ${_dns_record_id}"
+
   return 0
 }
 
-_delete_txt_record() {
-  _dns_record_id=$1
+_delete_record() {
+  local domain_id="$1"
+  local dns_record_id="$2"
 
-  if ! _dynu_rest DELETE "dns/$DynuDnsId/record/$_dns_record_id" ""; then
+  if ! _dynu_rest DELETE "dns/$domain_id/record/$dns_record_id" ""; then
     return 1
   fi
 
@@ -127,26 +259,27 @@ _delete_txt_record() {
 }
 
 _dynu_rest() {
-  m=$1
+  m="$1"
   ep="$2"
   data="$3"
-  bashio::log.debug "$ep"
 
-  _H1="API-Key: $Dynu_Token"
+  _H1="API-Key: $DNS_API_TOKEN"
   _H2="Content-Type: application/json"
 
-   bashio::log.debug "$m" "$Dynu_EndPoint/$ep"
+  bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Performing REST API method: $m to endpoint: $DNS_API_ENDPOINT/$ep"
   if [ "$data" ]; then
-    response=$(curl -s -H "$_H1" -H "$_H2" -X $m "$Dynu_EndPoint/$ep" -d $data)
+    response=$(curl -s -H "$_H1" -H "$_H2" -X $m "$DNS_API_ENDPOINT/$ep" -d $data) # outgoing
   else
-    response=$(curl -s -H "$_H1" -H "$_H2" -X $m "$Dynu_EndPoint/$ep")
+    response=$(curl -s -H "$_H1" -H "$_H2" -X $m "$DNS_API_ENDPOINT/$ep") # incoming
   fi
 
-  if [ "$?" != "0" ]; then
-    bashio::log.error " _dynu_rest error is:  $ep"
+  local ret=$?
+  if [ "$ret" != "0" ]; then
+    bashio::log.warn "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "return code is: $ret"
     return 1
   fi
-  bashio::log.debug " _dynu_rest response is: $response"
+  bashio::log.trace "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "\nresponse='$(echo $response)' \n"
+
   return 0
 }
 

--- a/dynudns-addon/data/hooks.sh
+++ b/dynudns-addon/data/hooks.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bashio
+#!/usr/bin/with-contenv bashio
 # shellcheck disable=SC2034
 set -e
 
@@ -6,7 +6,7 @@ source dns_dynu.sh
 
 CONFIG_PATH=/data/options.json
 
-SYS_TOKEN=$(jq --raw-output '.token' $CONFIG_PATH)
+DNS_API_TOKEN=$(jq --raw-output '.dns_api_token' $CONFIG_PATH)
 SYS_CERTFILE=$(jq --raw-output '.lets_encrypt.certfile' $CONFIG_PATH)
 SYS_KEYFILE=$(jq --raw-output '.lets_encrypt.keyfile' $CONFIG_PATH)
 
@@ -32,11 +32,9 @@ deploy_challenge() {
     #   validation, this is what you want to put in the _acme-challenge
     #   TXT record. For HTTP validation it is the value that is expected
     #   be found in the $TOKEN_FILENAME file.
-
-    Dynu_Token=$SYS_TOKEN
-    dns_dynu_add $ALIAS $TOKEN_VALUE
-
-    bashio::log.info " + Settling down for 10s..."
+    bashio::log.info "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Deploying TXT Challenge for $ALIAS"
+    dns_dynu_add_txt_record $ALIAS $TOKEN_VALUE
+    bashio::log.info "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Settling down for 10s..."
     sleep 10
 
 }
@@ -51,8 +49,7 @@ clean_challenge() {
     #
     # The parameters are the same as for deploy_challenge.
 
-    Dynu_Token=$SYS_TOKEN
-    dns_dynu_rm $ALIAS $TOKEN_VALUE
+    dns_dynu_rm_record $ALIAS $TOKEN_VALUE
 }
 
 deploy_cert() {

--- a/dynudns-addon/data/le.sh
+++ b/dynudns-addon/data/le.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/with-contenv bashio
+
+CERT_DIR=/data/letsencrypt
+WORK_DIR=/data/workdir
+
+# CONSTANTS
+LE_RENEW_WAIT_SECONDS=43200
+
+# VARIABLES
+le_last_renewed_time=0
+
+function le_init(){
+    local LE_TERMS_ACCEPTED=$1
+
+    bashio::log.info "Initializing Lets Encrypt using CERT_DIR=$CERT_DIR and WORK_DIR=$WORK_DIR"
+
+    # Register/generate certificate if terms accepted
+    if $LE_TERMS_ACCEPTED; then
+        # Init folder structs
+        mkdir -p "${CERT_DIR}"
+        mkdir -p "${WORK_DIR}"
+
+        # Clean up possible stale lock file
+        if [ -e "${WORK_DIR}/lock" ]; then
+            rm -f "${WORK_DIR}/lock"
+            bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Reset dehydrated lock file"
+        fi
+
+        # Generate new certs
+        if [ ! -d "${CERT_DIR}/live" ]; then
+            # Create empty dehydrated config file so that this dir will be used for storage
+            touch "${WORK_DIR}/config"
+
+            if dehydrated --register --accept-terms --config "${WORK_DIR}/config"; then
+                bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Init Success dehydrated returned 0"
+                return 0
+            else
+                bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Init Fail, dehydrated returned not 0"
+                return 1
+            fi
+        fi
+    else
+        bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Terms must be accepted in add-on config"
+        exit 1
+    fi
+
+    return 0
+}
+
+# Function that performe a renew
+function le_renew() {
+    local LE_TERMS_ACCEPTED=$1
+    local DOMAINS=$2
+    local ALIASES=$3
+
+    if $LE_TERMS_ACCEPTED; then
+        now="$(date +%s)"
+        le_time_since_last_renew=$((now - le_last_renewed_time))
+        if [ $le_time_since_last_renew -ge $LE_RENEW_WAIT_SECONDS ]; then
+
+            local domain_args=()
+            local aliases=''
+
+            # Prepare domain for Let's Encrypt
+            for domain in ${DOMAINS}; do
+                for alias in $(jq --raw-output --exit-status "[.aliases[]|{(.alias):.domain}]|add.\"$domain\" | select(. != null)" "$CONFIG_PATH") ; do
+                    aliases="$aliases $alias"
+                    bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "alias $alias is not a valid domain."
+                    return 1
+                done
+            done
+
+            aliases="$(echo "${aliases}" | tr ' ' '\n' | sort | uniq)"
+
+            bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Combining DOMAINS and ALIASES into domain_args: ${DOMAINS} ${aliases}"
+
+            for domain in $(echo "${DOMAINS}" "${aliases}" | tr ' ' '\n' | sort | uniq); do
+                bashio::log.debug "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "domain is: ${domain}"
+                domain_args+=("--domain" "${domain}")
+            done
+
+            bashio::log.info "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "Running Dehydrated with domain_args: ${domain_args[@]}"
+            if dehydrated --cron --hook ./hooks.sh --challenge dns-01 "${domain_args[@]}" --out "${CERT_DIR}" --config "${WORK_DIR}/config"; then
+                le_last_renewed_time="$(date +%s)"
+                bashio::log.info "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}]" "dehydrated completed successfully."
+                return 0
+            else
+                bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "dehydrated did not complete successfully."
+                return 1
+            fi
+        else 
+            bashio::log.trace "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@"
+            bashio::log.debug "le_time_since_last_renew=$le_time_since_last_renew is not yet greater than $LE_RENEW_WAIT_SECONDS. Skipping LE renew for now..."
+
+            return 0
+        fi
+    else
+        bashio::log.error "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Terms must be accepted in add-on config"
+        exit 1
+    fi
+    return 0
+
+}

--- a/dynudns-addon/data/run.sh
+++ b/dynudns-addon/data/run.sh
@@ -1,174 +1,78 @@
 #!/usr/bin/with-contenv bashio
 
-#bashio::log.level "debug"
+# # Have BASH tell you which function it errored on, rather than exit silently.
+# function error_handler {
+#     local exit_code=$?
+#     local cmd="${BASH_COMMAND}" # Command that triggered the ERR
+#     echo "Error in script at: '${cmd}' with exit code: ${exit_code}"
+#     # Simple backtrace
+#     local frame=0
+#     while caller $frame; do
+#         ((frame++));
+#     done
+# }
+
+# trap 'error_handler' ERR
+
+bashio::log.level "info"
 
 source dns_dynu.sh
+source le.sh
+source ddns.sh
 
+CONFIG_PATH=/data/options.json
 
-CERT_DIR=/data/letsencrypt
-WORK_DIR=/data/workdir
+function update_dns_ip_addresses(){
 
-# Let's encrypt
-LE_UPDATE="0"
-
-# DynuDNS
-if bashio::config.has_value "ipv4"; then ipv4_fixed=$(bashio::config 'ipv4'); else ipv4_fixed=""; fi
-if bashio::config.has_value "ipv6"; then ipv6_fixed=$(bashio::config 'ipv6'); else ipv6_fixed=""; fi
-QUERY_URL_IPV4="https://ipv4.text.wtfismyip.com"
-QUERY_URL_IPV6="https://ipv6.text.wtfismyip.com"
-TOKEN=$(bashio::config 'token')
-DOMAINS=$(bashio::config 'domains')
-WAIT_TIME=$(bashio::config 'seconds')
-
-export Dynu_Token=$TOKEN 
-bashio::log.debug "Token:" "$Dynu_Token"
-
-# Function that performe a renew
-function le_renew() {
-    local domain_args=()
-    local aliases=''
-
-    # Prepare domain for Let's Encrypt
-    for domain in ${DOMAINS}; do
-        for alias in $(jq --raw-output --exit-status "[.aliases[]|{(.alias):.domain}]|add.\"${domain}\" | select(. != null)" /data/options.json) ; do
-            aliases="${aliases} ${alias}"
-        done
-    done
-
-    aliases="$(echo "${aliases}" | tr ' ' '\n' | sort | uniq)"
-
-    bashio::log.info "Renew certificate for domains: $(echo -n "${DOMAINS}") and aliases: $(echo -n "${aliases}")"
-
-    for domain in $(echo "${DOMAINS}" "${aliases}" | tr ' ' '\n' | sort | uniq); do
-        domain_args+=("--domain" "${domain}")
-    done
-
-    dehydrated --cron --hook ./hooks.sh --challenge dns-01 "${domain_args[@]}" --out "${CERT_DIR}" --config "${WORK_DIR}/config" || true
-    LE_UPDATE="$(date +%s)"
-}   
-
-bashio::log.info "Initializing Dynu DNS Home Assistant Add-On for Domain(s): $(echo -n "${DOMAINS}")"
-
-# Register/generate certificate if terms accepted
-if bashio::config.true 'lets_encrypt.accept_terms'; then
-    # Init folder structs
-    mkdir -p "${CERT_DIR}"
-    mkdir -p "${WORK_DIR}"
-
-    # Clean up possible stale lock file
-    if [ -e "${WORK_DIR}/lock" ]; then
-        rm -f "${WORK_DIR}/lock"
-        bashio::log.warning "Reset dehydrated lock file"
+    declare current_ipv4_address
+    if ! hassio_determine_ipv4_address; then
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Could not determine IPv4 address"
     fi
 
-    # Generate new certs
-    if [ ! -d "${CERT_DIR}/live" ]; then
-        # Create empty dehydrated config file so that this dir will be used for storage
-        touch "${WORK_DIR}/config"
-
-        dehydrated --register --accept-terms --config "${WORK_DIR}/config"
-    fi
-fi
-
-bashio::log.info "Entering main Dynu DNS loop"
-# Run dynu
-while true; do
-
-    # Determine IPv4 Address
-    if [[ -n "$ipv4_fixed" ]]; then # use fixed IPv4 address
-        bashio::log.info "Using parsed argument for fixed IPv4: ${ipv4_fixed}"
-        if [[ ${ipv4_fixed} == *.* ]]; then
-            ipv4=${ipv4_fixed}
-        else
-            bashio::log.error "It appears the Add-On Argument: ipv4_fixed is not an IP address "
-            exit 1
-        fi
-    else  # Ask external server for my IPv4 address, since HA probably doesn't know it.
-        ipv4_queried=$(curl -s -f -m 10 "${QUERY_URL_IPV4}")
-        if [[ ${ipv4_queried} == *.* ]]; then
-            bashio::log.info "According to: ${QUERY_URL_IPV4} , IPv4 address is ${ipv4_queried}"
-            ipv4=${ipv4_queried}
-        else
-            bashio::log.warning "It appears ipv4_queried: ${ipv4_queried} returned from ${QUERY_URL_IPV4} is not an IP address "
-            sleep 5
-            continue
-        fi
-
-    fi
-
-    # Determine IPv6 Address
-    if [[ -n "$ipv6_fixed" ]]; then # use fixed IPv6 address
-        bashio::log.info "Using parsed argument for fixed IPv6: ${ipv6_fixed}"
-        if [[ ${ipv6_fixed} == *.* ]]; then
-            ipv6=${ipv6_fixed}
-        else
-            bashio::log.error "It appears the Add-On Argument: ipv6_fixed is not an IP address "
-            sleep 5
-            exit 1
-        fi
-    else  # Get IPv6 address from HA API, since add-on container does not have IPv6 address.
-        ipv6=
-        bashio::cache.flush_all
-        for addr in $(bashio::network.ipv6_address); do
-	    # Skip non-global addresses
-	    if [[ ${addr} != fe80:* && ${addr} != fc* && ${addr} != fd* ]]; then
-              ipv6=${addr%/*}
-              bashio::log.info "According to the HA Supervisor API, IPv6 address is ${ipv6}"
-              break
-            fi
-        done
+    declare current_ipv6_address
+    if ! hassio_determine_ipv6_address; then
+        bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Could not determine IPv6 address"
     fi
 
     # Update each domain
     for domain in ${DOMAINS}; do
-
-        # Get current domain configuration
-        _get_domain_id "${domain}"
-        bashio::log.info "Getting current domain configuration for domain: ${domain}"
-        bashio::log.debug "DynuDnsId: ${DynuDnsId}"
-
-        current_domain_config="$(curl -s -f -H "API-Key: $TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$DynuDnsId")"
-        current_ipv4_address=$(echo "$current_domain_config" | jq -r '.ipv4Address')
-        current_ipv6_address=$(echo "$current_domain_config" | jq -r '.ipv6Address')
-        statusCode=$(echo "$current_domain_config" | jq '.statusCode')
-
-        # Create new domain configuration
-        new_domain_config=$current_domain_config
-        if  [ "$statusCode" -eq 200 ]; then
-            bashio::log.info "  - Dynu DNS get config Success. \"statusCode\": $statusCode"
-            if  [[ "${ipv4}" == *.* ]]; then # Replace ipv4Address and ipv4 fields
-                new_domain_config=$(echo "$new_domain_config" | jq ".ipv4Address = \"${ipv4}\" | .ipv4 = true")
-            fi
-            if  [[ "${ipv6}" == *:* ]]; then # Replace ipv6Address and ipv6 fields
-                new_domain_config=$(echo "$new_domain_config" | jq ".ipv6Address = \"${ipv6}\" | .ipv6 = true")
-            fi
-        else
-            bashio::log.warning "  - Dynu DNS get config failed, not \"statusCode:\" ${statusCode}. It answered: ${answer}"
-            break
-        fi
-
-        # Update Domain config if it's different
-        bashio::log.info "Updating Dynu DNS: ${domain} IP addresses"
-        if [[ "$current_ipv4_address" != "$ipv4" ]] || [[ "$current_ipv6_address" != "$ipv6" ]] ; then
-
-            answer="$(curl -s -f -X POST -H "API-Key: $TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$DynuDnsId" -d "${new_domain_config}")"
-            statusCode=$(echo "$answer" | jq '.statusCode')
-
-            if [ "$statusCode" -eq 200 ]; then
-                bashio::log.info "  - Dynu DNS IP update Success: "statusCode:" ${statusCode}"
-            else
-                bashio::log.warning "  - Dynu DNS IP update did not succeed. "statusCode:" "$statusCode" . It answered: ${answer}"
-            fi
-        else
-            bashio::log.info "  - Skipping IP update since the IPv4 and IPv6 addresses are the same as on Dynu DNS."
-
+        if ! dns_dynu_update_ipv4_ipv6 "$domain" "$current_ipv4_address" "$current_ipv6_address"; then
+            bashio::log.warning "[${FUNCNAME[0]} ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Could not update Dynu DNS IP address records for domain: $domain"
+            continue
         fi
     done
 
-    now="$(date +%s)"
-    if bashio::config.true 'lets_encrypt.accept_terms' && [ $((now - LE_UPDATE)) -ge 43200 ]; then
-        le_renew
+    return 0
+
+}
+
+## INIT
+bashio::log.info "[dynudns- Add On] Initializing Dynu DNS Home Assistant Add-On"
+
+# get config variables from hassio
+if ! hassio_get_config_variables; then
+        bashio::log.error "[DynuDNS Add-On ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Failed to get config arguments from Add On Config"
+        exit 1
+fi
+
+# initialize lets encrypt
+if ! le_init $LE_TERMS_ACCEPTED; then
+        bashio::log.error "[DynuDNS Add-On ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Lets Encrypt Init failed."
+        exit 1
+fi
+
+bashio::log.info "[DynuDNS Add-On]" "Entering main Dynu DNS and Let's Encrypt Renew loop"
+while true; do
+
+    # update IP Addresses
+    if ! update_dns_ip_addresses; then
+        bashio::log.warning "[DynuDNS Add-On ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "Could not update Dynu DNS IP address"
     fi
 
-    sleep "${WAIT_TIME}"
+    # update certificates
+    if ! le_renew $LE_TERMS_ACCEPTED "$DOMAINS" "$ALIASES"; then
+        bashio::log.warning "[DynuDNS Add-On ${BASH_SOURCE[0]}:${LINENO}] Args: $@" "lets encrypt renew failed."
+    fi
+
+    sleep "${IP_UPDATE_WAIT_SECONDS}"
 done


### PR DESCRIPTION
Hello,

I noticed a bug in the recent PR #14  I submitted:
When using jq, and the records are missing (IE domain does not exist), it fails silently, rather than triggering error handling. This can cause quite a few unintended failures and crashes. The fix was to add the missing '-e' flag in the relevant jq commands.

Unfortunataly, it took me several hours to find the bug, and I ended up re-writing the whole add-on in desparation.

Additional benefits:
- Error Handling everywhere
- Code is more modular in separate files
- Main executable is reduced and simplified.

@koying Apologies for the double-work on the validation: I think this final PR has become a pretty solid plug-in now!

Please note, I edited some variable name from in config.json. I recommend deleting the add-on and re-adding it, to make sure the config.json is parsed again. (Rebuild is not sufficient!)