### PR TITLE
fix: prevent add-on crash on network disconnect (DSL reconnect)

### DIFF
--- a/dynudns-addon/data/dns_dynu.sh
+++ b/dynudns-addon/data/dns_dynu.sh
@@ -84,8 +84,8 @@ _get_domain_id() {
 
   bashio::log.debug "$domain" "$response"
 
-  if jq --arg name "$domain" 'any(.domains[]; .name == $name)'; then
-    DynuDnsId=$(echo $response | jq --arg name "$domain" '.domains[] | select(.name == $name) | .id')
+  if echo "$response" | jq --arg name "$domain" 'any(.domains[]; .name == $name)'; then
+    DynuDnsId=$(echo "$response" | jq --arg name "$domain" '.domains[] | select(.name == $name) | .id')
     bashio::log.debug "Fetched DynuDnsId: " "${DynuDnsId}"
     return 0
   fi

--- a/dynudns-addon/data/run.sh
+++ b/dynudns-addon/data/run.sh
@@ -123,11 +123,18 @@ while true; do
     for domain in ${DOMAINS}; do
 
         # Get current domain configuration
-        _get_domain_id "${domain}"
+        if ! _get_domain_id "${domain}"; then
+            bashio::log.warning "Could not get domain ID for ${domain}, skipping update (network issue?)"
+            continue
+        fi
         bashio::log.info "Getting current domain configuration for domain: ${domain}"
         bashio::log.debug "DynuDnsId: ${DynuDnsId}"
 
-        current_domain_config="$(curl -s -f -H "API-Key: $TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$DynuDnsId")"
+        current_domain_config="$(curl -s -f -m 10 -H "API-Key: $TOKEN" -H "Content-Type: application/json" "https://api.dynu.com/v2/dns/$DynuDnsId")"
+        if [[ -z "$current_domain_config" ]]; then
+            bashio::log.warning "Empty response from Dynu API for ${domain}, skipping (network issue?)"
+            continue
+        fi
         current_ipv4_address=$(echo "$current_domain_config" | jq -r '.ipv4Address')
         current_ipv6_address=$(echo "$current_domain_config" | jq -r '.ipv6Address')
         statusCode=$(echo "$current_domain_config" | jq '.statusCode')


### PR DESCRIPTION
## Problem

The add-on exits spontaneously when the internet connection drops temporarily (e.g. nightly DSL reconnect by the ISP). The log shows the add-on stopping cleanly right after `Entering main Dynu DNS loop` with no error message of its own — only s6 shutdown messages.

**Root cause:** `bashio` sets `set -e` internally, so any unhandled non-zero exit code terminates the add-on immediately.

## Fixes

**1. Catch `_get_domain_id` failures in `run.sh`**
The return value of `_get_domain_id` was not checked. On a network failure it returns `1`, which with `set -e` kills the add-on. Now it logs a warning and does `continue` to retry on the next loop iteration.

**2. Fix `jq` reading from stdin in `dns_dynu.sh`**
`jq` was called without piping `$response` to it, so it read from stdin and crashed/hung when there was no input. Changed to `echo "$response" | jq ...`.

**3. Add timeout and empty-response guard for Dynu API call in `run.sh`**
Added `-m 10` timeout to the `curl` call and a check for an empty response body, so `jq` never receives an empty string when the API is unreachable.

## Result

The add-on now survives a temporary network outage and resumes normal operation once connectivity is restored.